### PR TITLE
Update print_arg.c

### DIFF
--- a/ft_printf/print_arg.c
+++ b/ft_printf/print_arg.c
@@ -18,7 +18,7 @@ int	print_arg(va_list ap, t_info *info)
 
 	type = info->type;
 	if (type == 'c')
-		return (print_char(va_arg(ap, int), info));
+		return (print_char(va_arg(ap, char), info));
 	else if (type == 's')
 		return (print_string(va_arg(ap, char *), info));
 	else if (type == 'd' || type == 'i')


### PR DESCRIPTION
Isn't `v_arg (ap, char)` right instead of `va_arg (ap, int)` when printing 'c' type?
If there's a reason why I did it int, please let me know.